### PR TITLE
Octave: split around "@result{}" blocks if no ">>" prompts

### DIFF
--- a/doctest.m
+++ b/doctest.m
@@ -182,6 +182,8 @@ end
 % that docstring
 %
 
+[red, yellow, reset] = terminal_escapes();
+
 all_results = cell(1, length(to_test));
 all_extract_err = cell(1, length(to_test));
 all_extract_msgs = cell(1, length(to_test));
@@ -237,16 +239,17 @@ for i = 1:total
   end
 end
 
+[red, yellow, reset] = terminal_escapes();
 
 if total == 0 && extract_err < 0
-  fprintf(err, '%s: Warning: could not extract tests\n', to_test.name);
+  fprintf(err, ['%s: ' yellow  'Warning: could not extract tests' reset '\n'], to_test.name);
   fprintf(err, '  %s\n', extract_msg);
 elseif total == 0
   fprintf(err, '%s: NO TESTS\n', to_test.name);
 elseif errors == 0
   fprintf(out, '%s: OK (%d tests)\n', to_test.name, length(results));
 else
-  fprintf(err, '%s: %d ERRORS\n', to_test.name, errors);
+  fprintf(err, ['%s: ' red '%d ERRORS' reset '\n'], to_test.name, errors);
 end
 for I = 1:length(results)
   if ~results(I).pass
@@ -339,4 +342,26 @@ function [docstring, err, msg] = octave_extract_doctests(name)
   end
   % strip the @result{} bits
   docstring = regexprep(docstring, '@result\s*{}', '');
+end
+
+
+function [red, yellow, reset] = terminal_escapes()
+
+  try
+    OCTAVE_VERSION;
+    running_octave = 1;
+  catch
+    running_octave = 0;
+  end
+
+  if (running_octave)
+    % terminal escapes for Octave colour, hide from Matlab inside eval
+    red = eval('"\033[1;40;31m"');
+    yellow = eval('"\033[1;40;33m"');
+    reset = eval('"\033[m"');
+  else
+    red = '';
+    yellow = '';
+    reset = '';
+  end
 end

--- a/doctest.m
+++ b/doctest.m
@@ -189,9 +189,9 @@ all_extract_err = cell(1, length(to_test));
 all_extract_msgs = cell(1, length(to_test));
 
 if running_octave
-  disp('===========================================================================')
-  disp('Might see temporary output (github.com/catch22/doctest-for-matlab/issues/6)');
-  disp('===========================================================================')
+  disp('==========================================================================')
+  disp('Start of temporary output (github.com/catch22/doctest-for-matlab/issues/6)');
+  disp('==========================================================================')
 end
 
 for I = 1:length(to_test)
@@ -216,9 +216,12 @@ for I = 1:length(to_test)
     %print_test_results(to_test(I), these_results, err, msg);
 end
 
-disp('')
-disp('- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -')
-disp('')
+if running_octave
+  disp('========================================================================')
+  disp('End of temporary output (github.com/catch22/doctest-for-matlab/issues/6)');
+  disp('========================================================================')
+end
+
 for I=1:length(all_results);
   print_test_results(to_test(I), all_results{I}, all_extract_err{I}, all_extract_msgs{I});
 end

--- a/doctest.m
+++ b/doctest.m
@@ -5,7 +5,7 @@ function doctest(varargin)
 % doctest('func_name')
 % doctest class_name
 % doctest('class_name')
-% doctest class_name1 func_name2 class_name2 ...
+% doctest class_name1 func_name2 class_name3 ...
 %
 % Example:
 % Say you have a function that adds 7 to things:

--- a/doctest.m
+++ b/doctest.m
@@ -171,7 +171,7 @@ if (~running_octave)
   theMethods = methods(func_or_class);
 else
   % Octave unhappy on methods(<non-class>)
-  if (exist(func_or_class, 'file'))
+  if (exist(func_or_class, 'file') || exist(func_or_class, 'builtin'))
     theMethods = [];
   else
     theMethods = methods(func_or_class);

--- a/doctest.m
+++ b/doctest.m
@@ -308,11 +308,13 @@ function [docstring, err, msg] = octave_extract_doctests(name)
     docstring = strjoin(T, '\n');
   end
 
-  if (isempty(docstring))
+  if (isempty(docstring) || ~isempty(regexp(docstring, '^\s*$')))
     err = -1;  msg = 'empty @example blocks';
     docstring = '';
     return
-  elseif (~isempty(strfind(docstring, '>>')))
+  end
+
+  if (~isempty(strfind(docstring, '>>')))
     %% Has '>>' indicators
     err = 1;  msg = 'used >>';
   else

--- a/doctest.m
+++ b/doctest.m
@@ -320,8 +320,8 @@ function [docstring, err, msg] = octave_extract_doctests(name)
     II = ~cellfun('isempty', S);
     if (nnz(II) == 0)
       err = -2;  msg = 'has @example blocks but neither ">>" nor "@result{}"';
-      %docstring = '';
-      break
+      docstring = '';
+      return
     end
     if II(1)
       err = -4;  msg = 'no command: @result on first line?';

--- a/doctest.m
+++ b/doctest.m
@@ -98,7 +98,7 @@ function doctest(func_or_class, varargin)
 % BLANK LINES (or anyway, lines with just the comment marker % and nothing
 % else).
 %
-% All adjascent white space is collapsed into a single space before
+% All adjacent white space is collapsed into a single space before
 % comparison, so right now it can't detect anything that's purely a
 % whitespace difference.
 %

--- a/doctest.m
+++ b/doctest.m
@@ -113,6 +113,29 @@ function doctest(func_or_class, varargin)
 % below)
 %
 %
+% OCTAVE-SPECIFIC NOTES:
+%
+% Octave m-files are commonly documented using Texinfo.  If you are running
+% Octave and your m-file contains texinfo markup, then the rules noted above
+% are slightly different.  First, text outside of "@example" ... "@end
+% example" blocks is discarded.  As only examples are expected in those
+% blocks, the two-blank-lines convention is not required.  A minor amount of
+% reformatting is done (e.g., stripping the pagination hints "@group").
+%
+% Conventionally, Octave documentation indicates results with "@result{}"
+% (which renders to an arrow).  If the text contains no ">>" prompts, we try
+% to guess where they should be based on splitting around the "@result{}"
+% indicators.  Additionally, all lines from the start of the "@example"
+% block to the first "@result{}" are assumed to be commands.  These
+% heuristics work for simple documentation but for more complicated
+% examples, adding ">>" to the documentation may be necessary.
+% FIXME: Instead of the current pre-parsing to add ">>" prompts, one could
+% presumably refactor the testing code so that input lines are tried
+% one-at-a-time checking the output after each.
+%
+%
+% VERSIONS:
+%
 % The latest version from the original author, Thomas Smith, is available
 % at http://bitbucket.org/tgs/doctest-for-matlab/src
 %

--- a/doctest.m
+++ b/doctest.m
@@ -281,8 +281,8 @@ function [docstring, err, msg] = octave_extract_doctests(name)
   %docstring = eval('__makeinfo__(docstring, "plain text")');
 
   % strip @group, and escape sequences
-  docstring = strrep(docstring, sprintf('@group\n'), '');
-  docstring = strrep(docstring, sprintf('@end group\n'), '');
+  docstring = regexprep(docstring, '^\s*@group\n', '\n', 'lineanchors');
+  docstring = regexprep(docstring, '@end group\n', '');
   docstring = strrep(docstring, '@{', '{');
   docstring = strrep(docstring, '@}', '}');
   docstring = strrep(docstring, '@@', '@');
@@ -371,8 +371,8 @@ function [docstring, err, msg] = octave_extract_doctests(name)
     end
     docstring = strjoin(L, '\n');
   end
-  docstring = strrep(docstring, '@example', '');
-  docstring = strrep(docstring, '@end example', '');
+  docstring = regexprep(docstring, '^\s*@example\n', '', 'lineanchors');
+  docstring = regexprep(docstring, '^\s*@end example\n', '\n\n', 'lineanchors');
   docstring = regexprep(docstring, '@result\s*{}', '');
 end
 

--- a/doctest_run.m
+++ b/doctest_run.m
@@ -87,6 +87,18 @@ end
 
 function formatted = DOCTEST__format_exception(ex)
 
+  try
+    OCTAVE_VERSION;
+    running_octave = 1;
+  catch
+    running_octave = 0;
+  end
+
+  if running_octave
+      formatted = ['??? ' ex.message];
+      return
+  end
+
 if strcmp(ex.stack(1).name, 'DOCTEST__evalc')
     % we don't want the report, we just want the message
     % otherwise it'll talk about evalc, which is not what the user got on

--- a/doctest_run.m
+++ b/doctest_run.m
@@ -87,10 +87,7 @@ end
 
 function formatted = DOCTEST__format_exception(ex)
 
-if ~ isfield(ex, 'stack')
-    % FIXME: do octave exceptions have stack?  not parse error anyway
-    formatted = ['??? ' ex.message];
-elseif strcmp(ex.stack(1).name, 'DOCTEST__evalc')
+if strcmp(ex.stack(1).name, 'DOCTEST__evalc')
     % we don't want the report, we just want the message
     % otherwise it'll talk about evalc, which is not what the user got on
     % the command line.


### PR DESCRIPTION
These basically improve Octave support, even when there are no ">>".  In principle, this makes no changes to how it works on Matlab and I've very lightly tested it on Matlab.