### PR TITLE
fix for output consisting only of symbols (non-words)

### DIFF
--- a/doctest_run.m
+++ b/doctest_run.m
@@ -22,7 +22,7 @@ if length(matches) > 0
 end
 
 % loosely based on Python 2.6 doctest.py, line 510
-example_re = '(?m)(?-s)(?:^ *>> )(.*(\n *\.\. .*)*)\n((?:(?:^ *$\n)?(?!\s*>>).*\w.*\n)*)';
+example_re = '(?m)(?-s)(?:^ *>> )(.*(\n *\.\. .*)*)\n((?:(?:^ *$\n)?(?!\s*>>).*\S.*\n)*)';
 [~,~,~,~,examples] = regexp(docstring, example_re);
 
 for i = 1:length(examples)


### PR DESCRIPTION
Use `\S` instead of `\w` to in a regular expression.

Fixes #12.