### PR TITLE
match the whole string: anchor the regexp ends

### DIFF
--- a/doctest_compare.m
+++ b/doctest_compare.m
@@ -40,7 +40,7 @@ end
 
 want_escaped = regexptranslate('escape', want);
 want_re = regexprep(want_escaped, '(\\\*){3}', '.*');
-
+want_re = ['^' want_re '$'];
 
 
 result = regexp(got, want_re, 'once');

--- a/doctest_run.m
+++ b/doctest_run.m
@@ -41,12 +41,22 @@ end
 all_outputs = DOCTEST__evalc(examples);
 results = [];
 for i = 1:length(examples)
+  % collapse all space (FIXME: could try something more sophisticated)
   want_unspaced = regexprep(examples{i}{2}, '\s+', ' ');
   got_unspaced = regexprep(all_outputs{i}, '\s+', ' ');
+  want_unspaced = strtrim(want_unspaced);
+  got_unspaced = strtrim(got_unspaced);
   results(i).source = examples{i}{1};
   results(i).want = strtrim(want_unspaced);
   results(i).got = strtrim(got_unspaced);
-  results(i).pass = doctest_compare(want_unspaced, got_unspaced);
+  pass = doctest_compare(want_unspaced, got_unspaced);
+  % a list of acceptably-missing prefixes (allow customizing?)
+  prefix = {'', 'ans = '};
+  for ii = 1:length(prefix)
+    pass = doctest_compare([prefix{ii} want_unspaced], got_unspaced);
+    if pass break end
+  end
+  results(i).pass = pass;
 end
 
 end


### PR DESCRIPTION
Not sure this will work, maybe don't merge yet...

But it will in principle fix #14.

I know I'm relying on this bug because I often don't include "ans = " in my doctests!  But I may try to add that feature separately.
