### PR TITLE
syntax error fix on Matlab

### DIFF
--- a/doctest_run.m
+++ b/doctest_run.m
@@ -54,7 +54,7 @@ for i = 1:length(examples)
   prefix = {'', 'ans = '};
   for ii = 1:length(prefix)
     pass = doctest_compare([prefix{ii} want_unspaced], got_unspaced);
-    if pass break end
+    if pass, break, end
   end
   results(i).pass = pass;
 end


### PR DESCRIPTION
Tested on 2015a.  Maybe this syntax was ok in earlier versions?