### PR TITLE
Octave: multiline input fix

### DIFF
--- a/doctest.m
+++ b/doctest.m
@@ -426,9 +426,14 @@ function [docstring, err, msg] = octave_extract_doctests(name)
     I(Iex_start) = false;
     I(Iex_end) = false;
 
+    starts = [0 diff(I)] == 1;
     for i=1:length(L)
       if (I(i) && ~isempty(L{i}) && isempty(regexp(L{i}, '^\s+$', 'match')))
-        L{i} = ['>> ' L{i}];
+        if (starts(i))
+          L{i} = ['>> ' L{i}];
+        else
+          L{i} = ['.. ' L{i}];
+        end
       end
     end
     docstring = strjoin(L, '\n');

--- a/doctest_run.m
+++ b/doctest_run.m
@@ -25,11 +25,14 @@ end
 example_re = [
     '(?m)(?-s)'                          ... % options
     '(?:^ *>> )'                         ... % ">> "
-    '(.*(\n *\.\. .*)*)\n'               ... % rest of line + ".. " lines
+    '(.*(?:\n *\.\. .*)*)\n'             ... % rest of line + ".. " lines
     '((?:(?:^ *$\n)?(?!\s*>>).*\S.*\n)*)'];  % the output
 [~,~,~,~,examples] = regexp(docstring, example_re);
 
 for i = 1:length(examples)
+  % each block should be split into input/output by the regex
+  assert (length(examples{i}) == 2)
+
   % split into lines
   lines = textscan(examples{i}{1}, '%s', 'delimiter', sprintf('\n'));
   lines = lines{1};

--- a/doctest_run.m
+++ b/doctest_run.m
@@ -22,7 +22,11 @@ if length(matches) > 0
 end
 
 % loosely based on Python 2.6 doctest.py, line 510
-example_re = '(?m)(?-s)(?:^ *>> )(.*(\n *\.\. .*)*)\n((?:(?:^ *$\n)?(?!\s*>>).*\S.*\n)*)';
+example_re = [
+    '(?m)(?-s)'                          ... % options
+    '(?:^ *>> )'                         ... % ">> "
+    '(.*(\n *\.\. .*)*)\n'               ... % rest of line + ".. " lines
+    '((?:(?:^ *$\n)?(?!\s*>>).*\S.*\n)*)'];  % the output
 [~,~,~,~,examples] = regexp(docstring, example_re);
 
 for i = 1:length(examples)


### PR DESCRIPTION
reformat and comment the regex.  2nd commit has the actual minor change.

tested, still works on Matlab.